### PR TITLE
Increase unicorn workers to 20

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,6 +1,6 @@
 ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
-worker_processes 8
+worker_processes 20
 preload_app true
 pid File.join(ROOT, 'tmp', 'pids', 'unicorn.pid')
 stdout_path '/var/log/aaf/discovery/unicorn/stdout.log'


### PR DESCRIPTION
Now that the service is sitting stable on memory usage after the change in #49, we can afford a few more workers. Originally this was set to 40, but I think 20 is a reasonable mid point to trial before we ramp it up further (if we need to).

![](http://drawception.com/pub/panels/2013/5-12/2w8sqrWkfa-2.png)