### PR TITLE
Cleanup debug logging for update job

### DIFF
--- a/lib/discovery_service/metadata/entity_data_filter.rb
+++ b/lib/discovery_service/metadata/entity_data_filter.rb
@@ -3,15 +3,12 @@ module DiscoveryService
     # Filters entity data based on tag config
     module EntityDataFilter
       def filter(entity_data, tag_config)
-        logger.debug('Filtering with config: '\
-            "#{JSON.pretty_generate(tag_config)}")
         result = tag_config.reduce({}) do |hash, (group, tag_config_for_group)|
           entities = entity_data.select do |entity|
             contains_tags?(entity, tag_config_for_group)
           end
           hash.merge(group => entities)
         end
-        logger.debug("Result: #{JSON.pretty_generate(result)}")
         result
       end
 

--- a/lib/discovery_service/metadata/saml_service_client.rb
+++ b/lib/discovery_service/metadata/saml_service_client.rb
@@ -11,17 +11,11 @@ module DiscoveryService
         with_saml_service_client(url) do |http|
           response = http.request(req)
           response.value # Raise exception on HTTP error
-          parse_response(response)
+          JSON.parse(response.body, symbolize_names: true)
         end
       rescue Net::HTTPServerException => e
         log_error(e, saml_service_url)
         raise e
-      end
-
-      def parse_response(response)
-        json_response = JSON.parse(response.body, symbolize_names: true)
-        logger.debug "Built response: #{JSON.pretty_generate(json_response)}"
-        json_response
       end
 
       def with_saml_service_client(url)

--- a/lib/discovery_service/metadata/updater.rb
+++ b/lib/discovery_service/metadata/updater.rb
@@ -21,12 +21,14 @@ module DiscoveryService
       end
 
       def update
+        logger.info 'Update start'
         config = YAML.load_file('config/discovery_service.yml')
         raw_entities = retrieve_entity_data(config[:saml_service][:url])
         grouped_entities = filter(combine_sp_idp(raw_entities),
                                   group_config(config, :filters))
         save_entities(grouped_entities, group_config(config, :tag_groups),
                       config[:environment])
+        logger.info 'Update complete'
       end
 
       private

--- a/lib/discovery_service/metadata/updater.rb
+++ b/lib/discovery_service/metadata/updater.rb
@@ -74,7 +74,7 @@ module DiscoveryService
         page = render(:group, generate_group_model(entities, 'en',
                                                    tag_groups),
                       environment)
-        logger.debug("Storing page for group '#{group}': '#{page}'")
+        logger.info("Rebuilt page for group '#{group}'")
         @entity_cache.save_group_page(group, page)
       end
 


### PR DESCRIPTION
This was previously to noisy and caused disk full events in production.

Closes #59.