### PR TITLE
Feature/w3c validation and accessibility

### DIFF
--- a/assets/stylesheets/common.css.scss
+++ b/assets/stylesheets/common.css.scss
@@ -40,6 +40,10 @@ img {
   }
 }
 
+h1.ui.header {
+  font-size: 1.714rem;
+}
+
 #search_column {
   padding-left: $form_left_padding;
   padding-right: $form_right_padding;

--- a/assets/stylesheets/common.css.scss
+++ b/assets/stylesheets/common.css.scss
@@ -44,10 +44,6 @@ a {
   color: #297abf;
 }
 
-h1.ui.header {
-  font-size: 1.714rem;
-}
-
 #search_column {
   padding-left: $form_left_padding;
   padding-right: $form_right_padding;
@@ -164,6 +160,14 @@ h1.ui.header {
 
 .ui.modal {
   display: none;
+}
+
+.title {
+  font-size: 1.714rem !important;
+
+  .sub.header {
+    font-size: 1.14285714rem !important;
+  }
 }
 
 .header {

--- a/assets/stylesheets/common.css.scss
+++ b/assets/stylesheets/common.css.scss
@@ -176,3 +176,8 @@ h1.ui.header {
   margin-right: auto;
 }
 
+.hide {
+  position: absolute !important;
+  top: -9999px !important;
+  left: -9999px !important;
+}

--- a/assets/stylesheets/common.css.scss
+++ b/assets/stylesheets/common.css.scss
@@ -180,7 +180,7 @@ a {
   margin-right: auto;
 }
 
-.hide {
+.accessible {
   position: absolute !important;
   top: -9999px !important;
   left: -9999px !important;

--- a/assets/stylesheets/common.css.scss
+++ b/assets/stylesheets/common.css.scss
@@ -40,6 +40,10 @@ img {
   border-style: none;
 }
 
+a {
+  color: #297abf;
+}
+
 h1.ui.header {
   font-size: 1.714rem;
 }

--- a/assets/stylesheets/common.css.scss
+++ b/assets/stylesheets/common.css.scss
@@ -3,10 +3,6 @@ $form_right_padding: 0px !important;
 $mobile-max-width: 420px;
 $tablet-max-width: 767px;
 
-img {
-  border-style: none;
-}
-
 @media only screen and (max-width: $mobile-max-width) {
 
   #sp_header {
@@ -38,6 +34,10 @@ img {
   #status_links_column {
     padding-top: 0px !important;
   }
+}
+
+img {
+  border-style: none;
 }
 
 h1.ui.header {
@@ -139,6 +139,11 @@ h1.ui.header {
 #help_link {
   outline: 0;
   display: none;
+}
+
+.btn-accessible {
+  color: #ffffff !important;
+  background-color: #007bc5 !important;
 }
 
 .idp_selection_table_name_column {

--- a/spec/lib/discovery_service/renderer/page_renderer_spec.rb
+++ b/spec/lib/discovery_service/renderer/page_renderer_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe DiscoveryService::Renderer::PageRenderer do
 
       it 'includes the main (javascript enabled) idp selection button' do
         expect(subject)
-          .to include('<div class="ui fluid button large primary"'\
-            ' id="select_organisation_button">')
+          .to include('<div class="ui fluid button btn-accessible large'\
+            ' primary" id="select_organisation_button">')
       end
 
       it 'includes the organisations to select' do

--- a/spec/lib/discovery_service/renderer/page_renderer_spec.rb
+++ b/spec/lib/discovery_service/renderer/page_renderer_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe DiscoveryService::Renderer::PageRenderer do
       let(:idps) { [idp_1, idp_2] }
 
       let(:expected_open_form_tag) do
-        '<form action="" id="idp_selection_form" method="POST">'
+        '<form id="idp_selection_form" method="POST">'
       end
 
       it 'includes the selection string' do

--- a/views/_header.slim
+++ b/views/_header.slim
@@ -1,4 +1,4 @@
-h2.ui.header
+h1.ui.header
   img.ui.image src="/aaf_logo.png" alt="The Australian Access Federation" /
   .content
     | Discovery Service

--- a/views/_header.slim
+++ b/views/_header.slim
@@ -1,4 +1,4 @@
-h1.ui.header
+.ui.header.title
   img.ui.image src="/aaf_logo.png" alt="The Australian Access Federation" /
   .content
     | Discovery Service

--- a/views/_header.slim
+++ b/views/_header.slim
@@ -1,5 +1,5 @@
 h2.ui.header
-  img.ui.image src="/aaf_logo.png" /
+  img.ui.image src="/aaf_logo.png" alt="The Australian Access Federation" /
   .content
     | Discovery Service
     .sub.header

--- a/views/group.slim
+++ b/views/group.slim
@@ -9,7 +9,7 @@ script#sps(type='application/json')== JSON.generate(@sps)
 .ui.mobile.stackable.padded.grid
   .twelve.wide.column
     h1.ui.header
-      img#sp_header_logo.ui.image src="/aaf_logo.png" /
+      img#sp_header_logo.ui.image src="/aaf_logo.png" alt="The Australian Access Federation" /
       #sp_header.content
         ' Login to
         span.sp_header_name  Service

--- a/views/group.slim
+++ b/views/group.slim
@@ -31,7 +31,7 @@ script#sps(type='application/json')== JSON.generate(@sps)
     ' For a better experience, please upgrade to a
     a>(href="http://browsehappy.com/" tabindex="1") modern browser
     | and ensure Javascript is enabled.
-  form[id="idp_selection_form" action="" method="POST"]
+  form[id="idp_selection_form" method="POST"]
     .ui.form.attached.fluid
       #loader.ui.inverted.dimmer
         .ui.text.loader

--- a/views/group.slim
+++ b/views/group.slim
@@ -8,7 +8,7 @@ script#sps(type='application/json')== JSON.generate(@sps)
 
 .ui.mobile.stackable.padded.grid
   .twelve.wide.column
-    h2.ui.header
+    h1.ui.header
       img#sp_header_logo.ui.image src="/aaf_logo.png" /
       #sp_header.content
         ' Login to

--- a/views/group.slim
+++ b/views/group.slim
@@ -45,7 +45,7 @@ script#sps(type='application/json')== JSON.generate(@sps)
             #search_column.sixteen.wide.column
               .ui.left.icon.right.action.input.fluid
                 i.search.icon
-                label[for="search_input" class="hide"] Organisation:
+                label[for="search_input" class="accessible"] Organisation:
                 input#search_input placeholder=("Search for your organisation") type="text" autocomplete="off" /
                 #search_clear_button.ui.basic.floating.icon.button
                   i.remove.icon

--- a/views/group.slim
+++ b/views/group.slim
@@ -45,6 +45,7 @@ script#sps(type='application/json')== JSON.generate(@sps)
             #search_column.sixteen.wide.column
               .ui.left.icon.right.action.input.fluid
                 i.search.icon
+                label[for="search_input" class="hide"] Organisation:
                 input#search_input placeholder=("Search for your organisation") type="text" autocomplete="off" /
                 #search_clear_button.ui.basic.floating.icon.button
                   i.remove.icon
@@ -72,8 +73,8 @@ script#sps(type='application/json')== JSON.generate(@sps)
         #select_organisation_button.ui.fluid.button.btn-accessible.large.primary
       .field
         .ui.checkbox
-          input name="remember" type="checkbox" /
-          label Remember this selection permanently
+          input id="remember" name="remember" type="checkbox" /
+          label[for="remember"] Remember this selection permanently
 - else
   .ui.negative.message
     .header Error

--- a/views/group.slim
+++ b/views/group.slim
@@ -8,7 +8,7 @@ script#sps(type='application/json')== JSON.generate(@sps)
 
 .ui.mobile.stackable.padded.grid
   .twelve.wide.column
-    h1.ui.header
+    .ui.header.title
       img#sp_header_logo.ui.image src="/aaf_logo.png" alt="The Australian Access Federation" /
       #sp_header.content
         ' Login to

--- a/views/group.slim
+++ b/views/group.slim
@@ -69,7 +69,7 @@ script#sps(type='application/json')== JSON.generate(@sps)
                       td
                         button[type="submit" name="user_idp" value="#{idp[:entity_id]}" tabindex="#{@idps.index(idp) + 2}" class="button ui floated right button small select_organisation_input"] Select
       .field
-        #select_organisation_button.ui.fluid.button.large.primary
+        #select_organisation_button.ui.fluid.button.btn-accessible.large.primary
       .field
         .ui.checkbox
           input name="remember" type="checkbox" /

--- a/views/layout.slim
+++ b/views/layout.slim
@@ -20,7 +20,7 @@ html lang='en'
           .ui.horizontal.list
             .item
               a[href="http://www.aaf.edu.au" target="_blank" id="aaf_logo"]
-                img.ui.mini.circular.image src="/aaf_logo.png" /
+                img.ui.mini.circular.image src="/aaf_logo.png" alt="The Australian Access Federation" /
               .content[id="aaf_logo_content"]
                 .ui.sub.header Australian Access Federation
                 | #{@environment[:name]}

--- a/views/layout.slim
+++ b/views/layout.slim
@@ -1,8 +1,7 @@
 doctype html
 html lang='en'
-  head profile='http://www.w3.org/2005/10/profile'
+  head
     meta charset='utf-8'
-    meta http-equiv='X-UA-Compatible' content='IE=Edge,chrome=1'
     meta name='viewport' content='width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'
     title AAF Discovery Service
     /[if IE]

--- a/views/selected_idps.slim
+++ b/views/selected_idps.slim
@@ -18,7 +18,7 @@
               - if idp[:logo_url]
                 img.ui.image.tiny.bordered src="#{idp[:logo_url]}" /
     form[action="" method="POST"]
-      button[type="submit" id="reset_idp_selection_button" class="button ui fluid button large primary"] Reset
+      button[type="submit" id="reset_idp_selection_button" class="button ui fluid button btn-accessible large primary"] Reset
 - else
   .ui.info.message
     .header


### PR DESCRIPTION
Ensured the DS pages (http://localhost:8080/discovery and http://localhost:8080/discovery, http://localhost:8080/discovery/:group/) are HTML5 complaint & conform to accessibility rules found in `tota11y` (https://khan.github.io/tota11y/).

- https://validator.w3.org/nu/
![image](https://cloud.githubusercontent.com/assets/9734455/13237960/6d1ddeaa-da1b-11e5-924b-3528d8191c8f.png)
 
- tota11y — Green ticks for everything except the "link text" on the IdP selection page: 
![image](https://cloud.githubusercontent.com/assets/9734455/13238212/0afb2fa0-da1d-11e5-954b-86c79d1f10bb.png)
*N.B.* Most of these links are nested inside a `display: none` style, which *should* be ignored by screen readers. I'm still having a play around with this idea right as I write this PR, let me know if you have any suggestions.
 
Tested IdP selection and login on Chrome (desktop + android), Firefox, Opera, IE11, IE9, Safari (desktop + iOS).
 
Resolves https://github.com/ausaccessfed/discovery-service/issues/55.
Resolves https://github.com/ausaccessfed/discovery-service/issues/54.