### PR TITLE
Fixed defect where IdPs were displayed on all tabs

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -122,7 +122,8 @@ function enableTabs() {
     setFirstTabAsActive();
     $.fn.dataTable.ext.search.push(
         function (settings, data) {
-          var tagsForIdP = data[3];
+          var tagsForIdPAsString = data[3];
+          var tagsForIdP = tagsForIdPAsString.slice(1, -1).split(',');
           var selectedTab = $('#tab_menu a.active').attr('data-tab');
           return tagsForIdP.indexOf(selectedTab) != -1 || selectedTab == '*'
         }

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -123,7 +123,7 @@ function enableTabs() {
     $.fn.dataTable.ext.search.push(
         function (settings, data) {
           var tagsForIdPAsString = data[3];
-          var tagsForIdP = tagsForIdPAsString.slice(1, -1).split(',');
+          var tagsForIdP = tagsForIdPAsString.split(',');
           var selectedTab = $('#tab_menu a.active').attr('data-tab');
           return tagsForIdP.indexOf(selectedTab) != -1 || selectedTab == '*'
         }


### PR DESCRIPTION
This was caused by the incorrect assumption Datatables was returning me a Javascript array; turns out it was a string representation. Now I'm manually parsing the string to array and using it as I intended.