### PR TITLE
Correct text of strings that are HTML encoded

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -160,6 +160,17 @@ function getUrlParameter(sParam) {
   }
 }
 
+function decodeString(source) {
+  var textArea = document.createElement('textarea');
+  textArea.innerHTML = source;
+  decodedString = textArea.value; 
+
+  if ('remove' in Element.prototype) 
+      textArea.remove();
+
+  return decodedString;
+}
+
 function loadInitiatingSPDetails() {
   var spJson = $.parseJSON($('#sps').html());
   var initiatingSP = getUrlParameter('entityID');
@@ -168,10 +179,10 @@ function loadInitiatingSPDetails() {
     var sp = getSP(spJson, initiatingSP);
     if (sp == null) return;
 
-    $('.sp_header_name').text(sp.name);
+    $('.sp_header_name').text(decodeString(sp.name));
 
     if (sp.description) {
-      $('#sp_header_description').text(sp.description);
+      $('#sp_header_description').text(decodeString(sp.description));
     }
     if (sp.logo_url) {
       $('#sp_header_logo').attr("src", sp.logo_url);
@@ -205,7 +216,7 @@ function renderLogo(logoURL) {
 }
 
 function renderIdPDetails(idPName) {
-  return '<strong>' + idPName + '</strong><br/>';
+  return '<strong>' + decodeString(idPName) + '</strong><br/>';
 }
 
 function renderEntityIdInput(entityID) {


### PR DESCRIPTION
Data which is provided to JSON parse from `#idps` or `#sps` is
still HTML encoded. For example ' is represented by `&#39;`. Whilst this
is safe enough in terms of valid JSON strings it is errenous when shown
to end users e.g. "TRS&#39;s SP" is far from ideal.

This change ensures that strings which may contain this extra data is
corrected decoded. Furthermore use of `textArea` reduces the chance of
XSS injection via metadata source.

I did attempt to apply the decode process to the entire string prior to
JSON parsing but this unfortunately breaks in the brower for reasons I
was unable to fully correct, hence this approach.