### PR TITLE
Expand read_timeout when connected to SAML Service

### DIFF
--- a/lib/discovery_service/metadata/saml_service_client.rb
+++ b/lib/discovery_service/metadata/saml_service_client.rb
@@ -21,6 +21,7 @@ module DiscoveryService
       def with_saml_service_client(url)
         client = Net::HTTP.new(url.host, url.port)
         client.use_ssl = (url.scheme == 'https')
+        client.read_timeout = 120
         logger.info "Invoking SAML Service (#{url})"
         client.start { |http| yield http }
       end


### PR DESCRIPTION
Under full load in the test environment the upstream FR instance and
thus by extension the SAML Service instance is responding slowly.

This is leading to job timeouts which otherwise should complete
successfully. This change permits a longer window for these jobs to
complete in during those periods.

@rcaught: If you could merge prior to 1100 on 16/1/17 I'd appreciate it.