### PR TITLE
Add missing require of `net/http`

### DIFF
--- a/lib/discovery_service/metadata/saml_service_client.rb
+++ b/lib/discovery_service/metadata/saml_service_client.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'json'
+require 'net/http'
 
 module DiscoveryService
   module Metadata


### PR DESCRIPTION
After updating dependencies (#77), this now needs to be explicit.