### PR TITLE
When supported ensure responses are compressed

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -8,4 +8,5 @@ Bundler.require(:default)
 require_relative './init.rb'
 require 'discovery_service'
 
+use Rack::Deflater
 run DiscoveryService::Application


### PR DESCRIPTION
For responses that are processed via Sinatra start to use the `Rack::Deflater` middleware to save bandwidth and speed up client interactions.

```
$ curl -I -k -H "Accept-Encoding: gzip" http://localhost:8080/discovery/edugain/Ymrk5pqP3WTFK9yMpRZkkw?entityID=https%3A%2F%2Fvho.test.aaf.edu.au%2Fshibboleth&return=https%3A%2F%2Fvho.test.aaf.edu.au%2FShibboleth.sso%2FLogin%3FSAMLDS%3D1%26target%3Dhttps%253A%252F%252Fvho.test.aaf.edu.au%252Fsession%252Ffederated%252Ffederatedlogin#
[1] 35264
HTTP/1.1 200 OK
Date: Thu, 22 Feb 2018 04:59:31 GMT
Connection: close
Content-Type: text/html;charset=utf-8
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Vary: Accept-Encoding
Content-Encoding: gzip
Transfer-Encoding: chunked
```

```
$ curl -I -k http://localhost:8080/discovery/edugain/Ymrk5pqP3WTFK9yMpRZkkw?entityID=https%3A%2F%2Fvho.test.aaf.edu.au%2Fshibboleth&return=https%3A%2F%2Fvho.test.aaf.edu.au%2FShibboleth.sso%2FLogin%3FSAMLDS%3D1%26target%3Dhttps%253A%252F%252Fvho.test.aaf.edu.au%252Fsession%252Ffederated%252Ffederatedlogin#
[1] 35437
HTTP/1.1 200 OK
Date: Thu, 22 Feb 2018 05:00:57 GMT
Connection: close
Content-Type: text/html;charset=utf-8
Content-Length: 832894
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Vary: Accept-Encoding
```

In the case above responses are 114KB and 813KB respectively which is a very decent saving.

This PR is supported by https://github.com/ausaccessfed/aaf-ansible/pull/662