### PR TITLE
Restore hack to make IE 11 function properly

### DIFF
--- a/assets/stylesheets/application.css.scss
+++ b/assets/stylesheets/application.css.scss
@@ -64,6 +64,7 @@ a:hover {
   background-repeat: no-repeat;
   padding-left: 40px;
   padding-bottom: 32px;
+  display: inline-table;
 }
 
 #footer #environment span {


### PR DESCRIPTION
Without this hack IE 11 was incorrectly rendering the footer.

Confirmed correct result in IE 11 and have tested with FF, Chrome, Safari to ensure it renders correctly there as well.