### PR TITLE
Fix for CVE-2018-1000539, updating json-jwt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'redis'
 gem 'redis-namespace'
 gem 'slim'
 
-gem 'activesupport'
+gem 'activesupport', '~> 5.1.0'
 gem 'hashdiff'
 gem 'json-jwt'
 gem 'rack', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,9 +5,9 @@ GEM
     aaf-gumboot (1.2.0)
       accession (~> 1.0)
     accession (1.0.0)
-    activesupport (5.1.5)
+    activesupport (5.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
@@ -23,7 +23,7 @@ GEM
       aws-sdk-core (= 2.11.8)
     aws-sigv4 (1.0.2)
     backports (3.11.1)
-    bindata (2.4.2)
+    bindata (2.4.3)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -79,12 +79,10 @@ GEM
     i18n (0.7.0)
     jmespath (1.3.1)
     json (2.1.0)
-    json-jwt (1.9.2)
+    json-jwt (1.9.4)
       activesupport
       aes_key_wrap
       bindata
-      securecompare
-      url_safe_base64
     kgio (2.11.2)
     libv8 (3.16.14.19)
     listen (3.1.5)
@@ -164,7 +162,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    securecompare (1.0.0)
     shellany (0.0.1)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -214,7 +211,6 @@ GEM
     unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
-    url_safe_base64 (0.2.2)
     webmock (3.3.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -230,7 +226,7 @@ PLATFORMS
 
 DEPENDENCIES
   aaf-gumboot
-  activesupport
+  activesupport (~> 5.1.0)
   aws-sdk (~> 2)
   capybara
   codeclimate-test-reporter


### PR DESCRIPTION
Pin for active-support to ~>5.1.0 was also necessary as ~>5.2.0 caused
the introduction of faults in specs that should not have been present:

```
1) DiscoveryService::Application GET /api/discovery/:group with idp containing only mandatory fields returns the idp with no keys for empty fields
     Failure/Error:
       fields = entity.slice(:names, :logos, :tags,
                             :single_sign_on_endpoints)

     KeyError:
       key not found: :names
```