### PR TITLE
Validate return parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config/discovery_service.yml
 config/deploy.yml
 config/event_encryption_key.pem
 .sass-cache
+.idea

--- a/lib/discovery_service/application.rb
+++ b/lib/discovery_service/application.rb
@@ -127,7 +127,7 @@ module DiscoveryService
         record_cookie_selection(request, params, unique_id, saved_user_idp)
         handle_response(params)
       elsif passive?(params) && params[:return]
-        redirect to(params[:return])
+        handle_response(params)
       elsif group_exists?(group)
         @entity_cache.group_page(group)
       else

--- a/lib/discovery_service/application.rb
+++ b/lib/discovery_service/application.rb
@@ -97,6 +97,11 @@ module DiscoveryService
       slim :selected_idps
     end
 
+    def entity_exists?(group, entity_id)
+      entities = @entity_cache.entities_as_hash(group)
+      entities&.key?(entity_id)
+    end
+
     before %r{\A/discovery/([^/]+)(/.+)?\z} do |group, _|
       halt 400 unless valid_group_name?(group) && uri?(params[:entityID])
       halt 404 unless group_configured?(group)
@@ -108,11 +113,6 @@ module DiscoveryService
       path = "/discovery/#{group}/#{id}"
       path += "?#{request.query_string}" if request.query_string != ''
       redirect to(path)
-    end
-
-    def entity_exists?(group, entity_id)
-      entities = @entity_cache.entities_as_hash(group)
-      entities&.key?(entity_id)
     end
 
     get '/discovery/:group/:unique_id' do |group, unique_id|
@@ -135,14 +135,6 @@ module DiscoveryService
       end
     end
 
-    get '/api/discovery/:group' do |group|
-      content_type 'application/json;charset=utf-8'
-      return 400 unless valid_group_name?(group) && group_configured?(group)
-
-      entities = @entity_cache.entities_as_hash(group)
-      JSON.generate(build_api_response(entities))
-    end
-
     post '/discovery/:group/:unique_id' do |group, unique_id|
       return 400 unless valid_params?
       unless entity_exists?(group, params[:user_idp])
@@ -155,6 +147,14 @@ module DiscoveryService
 
       record_manual_selection(request, params, unique_id)
       handle_response(params)
+    end
+
+    get '/api/discovery/:group' do |group|
+      content_type 'application/json;charset=utf-8'
+      return 400 unless valid_group_name?(group) && group_configured?(group)
+
+      entities = @entity_cache.entities_as_hash(group)
+      JSON.generate(build_api_response(entities))
     end
 
     get '/error/missing_idp' do

--- a/lib/discovery_service/persistence/entity_cache.rb
+++ b/lib/discovery_service/persistence/entity_cache.rb
@@ -54,6 +54,8 @@ module DiscoveryService
         HashDiff.diff(stored_entities, to_hash(entities))
       end
 
+      # Indicates the 'default' discovery profile URL for the
+      # supplied entity_id
       def default_discovery_response(group, entity_id)
         return nil unless entities_exist?(group)
 
@@ -62,6 +64,19 @@ module DiscoveryService
                           entities[entity_id].key?(:discovery_response)
 
         entities[entity_id][:discovery_response]
+      end
+
+      # Provides all discovery profile URL for the supplied entity_id
+      def all_discovery_response(group, entity_id)
+        return nil unless entities_exist?(group)
+
+        entities = build_entities(entities(group))
+        return nil unless entities.key?(entity_id) &&
+                          entities[entity_id].key?(
+                            :all_discovery_response_endpoints
+                          )
+
+        entities[entity_id][:all_discovery_response_endpoints]
       end
 
       private

--- a/lib/discovery_service/persistence/entity_cache.rb
+++ b/lib/discovery_service/persistence/entity_cache.rb
@@ -54,7 +54,7 @@ module DiscoveryService
         HashDiff.diff(stored_entities, to_hash(entities))
       end
 
-      def discovery_response(group, entity_id)
+      def default_discovery_response(group, entity_id)
         return nil unless entities_exist?(group)
 
         entities = build_entities(entities(group))

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -20,10 +20,10 @@ module DiscoveryService
           if DiscoveryService.configuration[:restrict_return_url]
             if valid_return_url(params, return_url)
               @logger.info("Return URL provided by '#{params[:entityID]}' was valid")
-              return redirect_to(return_url, params)
+              redirect_to(return_url, params)
             else
               @logger.error("Return URL provided by '#{params[:entityID]}' was invalid, rejecting value")
-              return status 403
+              status 403
             end
           else
             if valid_return_url(params, return_url)
@@ -31,7 +31,7 @@ module DiscoveryService
             else
               @logger.error("Return URL provided by '#{params[:entityID]}' was invalid, would be rejected (config disabled)")
             end
-            return redirect_to(return_url, params)
+            redirect_to(return_url, params)
           end
         else
           @logger.info("Return URL not provided by '#{params[:entityID]}', fallback to default")

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -27,8 +27,13 @@ module DiscoveryService
 
       def sp_response_url(return_url, param_key, selected_idp)
         url = URI.parse(return_url)
-        key = param_key || :entityID
-        query_opts = URI.decode_www_form(url.query || '') << [key, selected_idp]
+        query_opts = URI.decode_www_form(url.query || '')
+
+        if selected_idp
+          key = param_key || :entityID
+          query_opts << [key, selected_idp]
+        end
+
         url.query = URI.encode_www_form(query_opts)
         url.to_s
       end

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -4,7 +4,7 @@ module DiscoveryService
   module Response
     # Module to handle user redirect / response
     module Handler
-      # rubocop:disable Metrics/LineLength, Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/LineLength, Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
       def handle_response(params)
         # Flow per sstc-saml-idp-discovery 2.4/5
         # Attempt to return to metadata valid return parameter else fallback
@@ -16,7 +16,7 @@ module DiscoveryService
         # we won't see any cases where a return URL will not be blocked
         # due to data already existing or being added to metadata and
         # this code will be simplified.
-        if return_url && !return_url.empty?
+        if return_url&.present?
           if DiscoveryService.configuration[:restrict_return_url]
             if valid_return_url(params, return_url)
               @logger.info("Return URL provided by '#{params[:entityID]}' was valid")
@@ -42,7 +42,7 @@ module DiscoveryService
           status 404
         end
       end
-      # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
 
       private
 

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -5,10 +5,12 @@ module DiscoveryService
     # Module to handle user redirect / response
     module Handler
       def handle_response(params)
+        ddre = default_discovery_response(params)
+
         if params[:return]
           redirect_to(params[:return], params)
-        elsif discovery_response(params)
-          redirect_to(discovery_response(params), params)
+        elsif ddre
+          redirect_to(ddre, params)
         else
           status 404
         end
@@ -16,8 +18,9 @@ module DiscoveryService
 
       private
 
-      def discovery_response(params)
-        @entity_cache.discovery_response(params[:group], params[:entityID])
+      def default_discovery_response(params)
+        @entity_cache.default_discovery_response(params[:group],
+                                                 params[:entityID])
       end
 
       def redirect_to(return_url, params)

--- a/spec/lib/discovery_service/application_spec.rb
+++ b/spec/lib/discovery_service/application_spec.rb
@@ -872,8 +872,8 @@ RSpec.describe DiscoveryService::Application do
     let(:existing_sp) { build_sp_data(['sp', group_name]) }
     let(:selected_idp) { existing_idp[:entity_id] }
     let(:form_content) { { user_idp: selected_idp } }
-    let(:requesting_sp) { Faker::Internet.url }
-    let(:sp_return_url) { Faker::Internet.url }
+    let(:requesting_sp) { existing_sp[:entity_id] }
+    let(:sp_return_url) { existing_sp[:all_discovery_response_endpoints].first }
     let(:unique_id) { SecureRandom.urlsafe_base64 }
     let(:base_path) { "/discovery/#{group_name}/#{unique_id}" }
 
@@ -996,12 +996,43 @@ RSpec.describe DiscoveryService::Application do
           run
         end
 
-        it 'returns http status code 302' do
-          expect(last_response.status).to eq(302)
+        context 'without enforcing return url configured' do
+          it 'returns http status code 302' do
+            expect(last_response.status).to eq(302)
+          end
+
+          it 'redirects back to sp using return url value' do
+            expect_matching_response(sp_return_url, 'entityID' => selected_idp)
+          end
         end
 
-        it 'redirects back to sp using return url value' do
-          expect_matching_response(sp_return_url, 'entityID' => selected_idp)
+        context 'with enforcing return url configured' do
+          let(:config) do
+            { restrict_return_url: true, groups: {}, environment:
+                { name: environment_name, status_url: environment_status_url } }
+          end
+
+          context 'with valid return url provided' do
+            it 'returns http status code 302' do
+              expect(last_response.status).to eq(302)
+            end
+
+            it 'redirects back to sp using return url value' do
+              expect_matching_response(sp_return_url,
+                                       'entityID' => selected_idp)
+            end
+          end
+
+          context 'with invalid return url provided' do
+            let(:path) do
+              "#{base_path}?entityID=#{requesting_sp}"\
+                '&return=https://attacker.com'
+            end
+
+            it 'returns http status code 403' do
+              expect(last_response.status).to eq(403)
+            end
+          end
         end
       end
 

--- a/spec/lib/discovery_service/persistence/entity_cache_spec.rb
+++ b/spec/lib/discovery_service/persistence/entity_cache_spec.rb
@@ -189,19 +189,22 @@ RSpec.describe DiscoveryService::Persistence::EntityCache do
     end
   end
 
-  describe '#discovery_response(group, entity_id)' do
+  describe '#default_discovery_response(group, entity_id)' do
     context 'when entity does not exist' do
-      subject { instance.discovery_response(group, Faker::Internet.url) }
+      subject do
+        instance.default_discovery_response(group, Faker::Internet.url)
+      end
+
       it { is_expected.to be_nil }
     end
 
     context 'when entity without discovery response exists' do
       let(:entity) do
-        build_entity_data.except(:discovery_response)
+        build_entity_data.except(:default_discovery_response)
       end
       let(:entities) { to_hash([entity]).to_json }
       before { redis.set("entities:#{group}", entities) }
-      subject { instance.discovery_response(group, entity[:entity_id]) }
+      subject { instance.default_discovery_response(group, entity[:entity_id]) }
 
       it { is_expected.to be_nil }
     end
@@ -209,10 +212,10 @@ RSpec.describe DiscoveryService::Persistence::EntityCache do
       let(:entity) { build_entity_data }
       let(:entities) { to_hash([entity]).to_json }
       before { redis.set("entities:#{group}", entities) }
-      subject { instance.discovery_response(group, entity[:entity_id]) }
+      subject { instance.default_discovery_response(group, entity[:entity_id]) }
 
       it 'should eq discovery response' do
-        expect(subject).to eq(entity[:discovery_response])
+        expect(subject).to eq(entity[:default_discovery_response])
       end
     end
   end

--- a/spec/lib/discovery_service/persistence/entity_cache_spec.rb
+++ b/spec/lib/discovery_service/persistence/entity_cache_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe DiscoveryService::Persistence::EntityCache do
 
     context 'when entity without discovery response exists' do
       let(:entity) do
-        build_entity_data.except(:default_discovery_response)
+        build_sp_data.except(:discovery_response)
       end
       let(:entities) { to_hash([entity]).to_json }
       before { redis.set("entities:#{group}", entities) }
@@ -208,14 +208,48 @@ RSpec.describe DiscoveryService::Persistence::EntityCache do
 
       it { is_expected.to be_nil }
     end
+
     context 'when entity with discovery response exists' do
-      let(:entity) { build_entity_data }
+      let(:entity) { build_sp_data }
       let(:entities) { to_hash([entity]).to_json }
       before { redis.set("entities:#{group}", entities) }
       subject { instance.default_discovery_response(group, entity[:entity_id]) }
 
       it 'should eq discovery response' do
-        expect(subject).to eq(entity[:default_discovery_response])
+        expect(subject).to eq(entity[:discovery_response])
+      end
+    end
+  end
+
+  describe '#all_discovery_response(group, entity_id)' do
+    context 'when entity does not exist' do
+      subject do
+        instance.all_discovery_response(group, Faker::Internet.url)
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when entity without discovery response exists' do
+      let(:entity) do
+        build_sp_data.except(:discovery_response,
+                             :all_discovery_response_endpoints)
+      end
+      let(:entities) { to_hash([entity]).to_json }
+
+      before { redis.set("entities:#{group}", entities) }
+      subject { instance.all_discovery_response(group, entity[:entity_id]) }
+
+      it { is_expected.to be_nil }
+    end
+    context 'when entity with discovery response exists' do
+      let(:entity) { build_sp_data }
+      let(:entities) { to_hash([entity]).to_json }
+      before { redis.set("entities:#{group}", entities) }
+      subject { instance.all_discovery_response(group, entity[:entity_id]) }
+
+      it 'should eq discovery response' do
+        expect(subject).to eq(entity[:all_discovery_response_endpoints])
       end
     end
   end

--- a/spec/support/build_entity_data.rb
+++ b/spec/support/build_entity_data.rb
@@ -14,6 +14,8 @@ RSpec.shared_context 'build_entity_data' do
   def build_sp_data(tags = nil, lang = nil)
     entity_data = build_entity_data(tags, lang)
     entity_data[:discovery_response] = Faker::Internet.url
+    entity_data[:all_discovery_response_endpoints] =
+      [entity_data[:discovery_response]]
     entity_data[:information_urls] = [{ url: Faker::Internet.url, lang: lang }]
     entity_data[:descriptions] = [{ value: Faker::Lorem.sentence, lang: lang }]
     entity_data[:privacy_statement_urls] =


### PR DESCRIPTION
Requesting multiple eyes given criticality of DS function.

This PR ensures that this DS impl abides by the Identity Provider Discovery Service Protocol and Profile, section 2.5, that is ensuring that the DS will not send a user to an unregistered return URL.

This logic will need to be revisited at a future date to remove the ability to disable it. It exists in this form now so that existing DS deployments can act in a permissive mode and acquire logging about any
potential impact enabling this may have.

Several RuboCop metrics have been disabled for `handle_response`. Some may be removed by the refactoring required above at a later date, the remainder I don't consider offer any value in this specific case, open to discussion however.