### PR TITLE
Provide access to Application logger via reader

### DIFF
--- a/lib/discovery_service/application.rb
+++ b/lib/discovery_service/application.rb
@@ -19,6 +19,7 @@ module DiscoveryService
     include DiscoveryService::EmbeddedWAYF
 
     attr_reader :redis
+    attr_reader :logger
 
     set :assets_precompile,
         %w[application.js application.css]
@@ -48,7 +49,7 @@ module DiscoveryService
       @entity_cache = DiscoveryService::Persistence::EntityCache.new
       @groups = DiscoveryService.configuration[:groups]
       @environment = DiscoveryService.configuration[:environment]
-      @logger.info('Initialised with group configuration: '\
+      logger.info('Initialised with group configuration: '\
         "#{JSON.pretty_generate(@groups)}")
       @redis = Redis::Namespace.new(:discovery_service, redis: Redis.new)
     end

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -19,26 +19,26 @@ module DiscoveryService
         if return_url&.present?
           if DiscoveryService.configuration[:restrict_return_url]
             if valid_return_url(params, return_url)
-              @logger.info("Return URL provided by '#{params[:entityID]}' was valid")
+              logger.info("Return URL provided by '#{params[:entityID]}' was valid")
               redirect_to(return_url, params)
             else
-              @logger.error("Return URL provided by '#{params[:entityID]}' was invalid, rejecting value")
+              logger.error("Return URL provided by '#{params[:entityID]}' was invalid, rejecting value")
               status 403
             end
           else
             if valid_return_url(params, return_url)
-              @logger.info("Return URL provided by '#{params[:entityID]}' was valid (config diabled)")
+              logger.info("Return URL provided by '#{params[:entityID]}' was valid (config disabled)")
             else
-              @logger.error("Return URL provided by '#{params[:entityID]}' was invalid, would be rejected (config disabled)")
+              logger.error("Return URL provided by '#{params[:entityID]}' was invalid, would be rejected (config disabled)")
             end
             redirect_to(return_url, params)
           end
         else
-          @logger.info("Return URL not provided by '#{params[:entityID]}', fallback to default")
+          logger.info("Return URL not provided by '#{params[:entityID]}', fallback to default")
           return_url = default_discovery_response(params)
           return redirect_to(return_url, params) if return_url
 
-          @logger.info("Default return URL for '#{params[:entityID]}', not found")
+          logger.info("Default return URL for '#{params[:entityID]}', not found")
           status 404
         end
       end


### PR DESCRIPTION
In production it has been noted that logging is not successfully occuring even though it was shown to function correctly within rspec.

This change introduces an explicit accessor to help us confirm (or rule out) scoping issues as the cause for missing log statements.