### PR TITLE
Dont consider query string

### DIFF
--- a/lib/discovery_service/application.rb
+++ b/lib/discovery_service/application.rb
@@ -49,8 +49,6 @@ module DiscoveryService
       @entity_cache = DiscoveryService::Persistence::EntityCache.new
       @groups = DiscoveryService.configuration[:groups]
       @environment = DiscoveryService.configuration[:environment]
-      logger.info('Initialised with group configuration: '\
-        "#{JSON.pretty_generate(@groups)}")
       @redis = Redis::Namespace.new(:discovery_service, redis: Redis.new)
     end
 

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -49,7 +49,7 @@ module DiscoveryService
       def valid_return_url(params, return_url)
         # Per sstc-saml-idp-discovery the query path is not relevant
         # remove it if it exists in the return_url
-        ru = return_url [/[^\?]+/]
+        ru = return_url [/^[^\?]+/]
         @entity_cache
           .all_discovery_response(params[:group],
                                   params[:entityID])&.include?(ru)

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -22,14 +22,14 @@ module DiscoveryService
               logger.info("Return URL provided by '#{params[:entityID]}' was valid")
               redirect_to(return_url, params)
             else
-              logger.error("Return URL provided by '#{params[:entityID]}' was invalid, rejecting value")
+              logger.error("Return URL '#{return_url}' provided by '#{params[:entityID]}' was invalid, rejecting value")
               status 403
             end
           else
             if valid_return_url(params, return_url)
-              logger.info("Return URL provided by '#{params[:entityID]}' was valid (config disabled)")
+              logger.info("Return URL '#{return_url}' provided by '#{params[:entityID]}' was valid (config disabled)")
             else
-              logger.error("Return URL provided by '#{params[:entityID]}' was invalid, would be rejected (config disabled)")
+              logger.error("Return URL '#{return_url}' provided by '#{params[:entityID]}' was invalid, would be rejected (config disabled)")
             end
             redirect_to(return_url, params)
           end

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -47,9 +47,12 @@ module DiscoveryService
       private
 
       def valid_return_url(params, return_url)
+        # Per sstc-saml-idp-discovery the query path is not relevant
+        # remove it if it exists in the return_url
+        ru = return_url [/[^\?]+/]
         @entity_cache
           .all_discovery_response(params[:group],
-                                  params[:entityID])&.include?(return_url)
+                                  params[:entityID])&.include?(ru)
       end
 
       def default_discovery_response(params)


### PR DESCRIPTION
When comparing `return_url` values the query string should not be an active consideration.

Improved logging around `return_url` as part of this work.