### PR TITLE
Patch for CVE-2018-14404 (Nokigiri)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
   gem 'webmock'
 
   gem 'capybara', require: false
-  gem 'nokogiri', '1.8.2'
+  gem 'nokogiri', '1.10.3'
   gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'poltergeist', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,12 +94,12 @@ GEM
     lumberjack (1.0.13)
     method_source (0.9.0)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     nenv (0.3.0)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -245,7 +245,7 @@ DEPENDENCIES
   hashdiff
   i18n (~> 0.7.0)
   json-jwt
-  nokogiri (= 1.8.2)
+  nokogiri (= 1.10.3)
   phantomjs
   poltergeist
   pry


### PR DESCRIPTION
A NULL pointer dereference vulnerability exists in the xpath.c:xmlXPathCompOpEval() function of libxml2 through 2.9.8 when parsing an invalid XPath expression in the XPATH_OP_AND or XPATH_OP_OR case. Applications processing untrusted XSL format inputs with the use of the libxml2
library may be vulnerable to a denial of service attack due to a crash of the application.

Notified by GitHub security alerts, no linked AAF issue.