### PR TITLE
Add error page for 403 response

### DIFF
--- a/lib/discovery_service/application.rb
+++ b/lib/discovery_service/application.rb
@@ -164,6 +164,10 @@ module DiscoveryService
       slim :bad_request
     end
 
+    error 403 do
+      slim :forbidden
+    end
+
     error 404 do
       slim :not_found
     end

--- a/lib/discovery_service/application.rb
+++ b/lib/discovery_service/application.rb
@@ -160,6 +160,10 @@ module DiscoveryService
       slim :missing_idp
     end
 
+    get '/error/invalid_return_url' do
+      slim :invalid_return_url
+    end
+
     error 400 do
       slim :bad_request
     end

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -23,7 +23,7 @@ module DiscoveryService
               redirect_to(return_url, params)
             else
               logger.error("Return URL '#{return_url}' provided by '#{params[:entityID]}' was invalid, rejecting value")
-              status 403
+              redirect to('/error/invalid_return_url')
             end
           else
             if valid_return_url(params, return_url)

--- a/spec/lib/discovery_service/application_spec.rb
+++ b/spec/lib/discovery_service/application_spec.rb
@@ -1030,8 +1030,11 @@ RSpec.describe DiscoveryService::Application do
                 '&return=https://attacker.com'
             end
 
-            it 'returns http status code 403' do
-              expect(last_response.status).to eq(403)
+            it 'shows error page for invalid return_url' do
+              expect(last_response.status).to eq(302)
+              expect_matching_response(
+                'http://example.org/error/invalid_return_url', {}
+              )
             end
           end
         end

--- a/views/forbidden.slim
+++ b/views/forbidden.slim
@@ -1,9 +1,5 @@
   h2 Forbidden
   p We received a request that is not permitted.
-  p 
-    'A common cause of this fault is a missing or non matching
-    strong> DiscoveryResponse
-    |record in the associated SAML metadata entry.
 
   == Slim::Template.new('views/_support.slim').render
   br /

--- a/views/forbidden.slim
+++ b/views/forbidden.slim
@@ -1,8 +1,8 @@
   h2 Forbidden
-  p We received a request from a service that was misconfigured.
+  p We received a request that is not permitted.
   p 
-    |A common cause of this fault is a missing or non matching 
-    strong DiscoveryResponse 
+    'A common cause of this fault is a missing or non matching
+    strong> DiscoveryResponse
     |record in the associated SAML metadata entry.
 
   == Slim::Template.new('views/_support.slim').render

--- a/views/forbidden.slim
+++ b/views/forbidden.slim
@@ -1,0 +1,10 @@
+  h2 Forbidden
+  p We received a request from a service that was misconfigured.
+  p 
+    |A common cause of this fault is a missing or non matching 
+    strong DiscoveryResponse 
+    |record in the associated SAML metadata entry.
+
+  == Slim::Template.new('views/_support.slim').render
+  br /
+

--- a/views/invalid_return_url.slim
+++ b/views/invalid_return_url.slim
@@ -1,9 +1,13 @@
 h2 Invalid SAML configuration
 p We received a request that is not valid for the service being accessed.
 p 
-  'The cause of this fault is a missing or non matching
+  'The cause of this fault is an invalid
   strong> DiscoveryResponse
-  |record in the associated SAML metadata entry.
+  |record in the SAML metadata entry associated with the service being accesed.
+p 
+  'This value was provided as the parameter
+  strong> return_url
+  |by your browser during this request.
 
 == Slim::Template.new('views/_support.slim').render
 br /

--- a/views/invalid_return_url.slim
+++ b/views/invalid_return_url.slim
@@ -1,0 +1,9 @@
+h2 Invalid SAML configuration
+p We received a request that is not valid for the service being accessed.
+p 
+  'The cause of this fault is a missing or non matching
+  strong> DiscoveryResponse
+  |record in the associated SAML metadata entry.
+
+== Slim::Template.new('views/_support.slim').render
+br /


### PR DESCRIPTION
When users of services with invalid `return_url` triggered the new verification code they would be presented with a white page which was not good UX by any measure.

They will now be provided a much more specific message, with the common cause clearly identified so the metadata can be adjusted.