### PR TITLE
Fix typo, param is return not return_url

### DIFF
--- a/views/invalid_return_url.slim
+++ b/views/invalid_return_url.slim
@@ -6,7 +6,7 @@ p
   |record in the SAML metadata entry associated with the service being accesed.
 p 
   'This value was provided as the parameter
-  strong> return_url
+  strong> return
   |by your browser during this request.
 
 == Slim::Template.new('views/_support.slim').render


### PR DESCRIPTION
I deleted the four characters "_url" to make the message shown to users compliant to the OASIS SAML Identity Provider Discovery Service Protocol and Profile specification.