### PR TITLE
Provide error screen for unknown service

### DIFF
--- a/lib/discovery_service/application.rb
+++ b/lib/discovery_service/application.rb
@@ -164,6 +164,10 @@ module DiscoveryService
       slim :invalid_return_url
     end
 
+    get '/error/invalid_entity_id' do
+      slim :invalid_entity_id
+    end
+
     error 400 do
       slim :bad_request
     end

--- a/lib/discovery_service/persistence/entity_cache.rb
+++ b/lib/discovery_service/persistence/entity_cache.rb
@@ -54,6 +54,13 @@ module DiscoveryService
         HashDiff.diff(stored_entities, to_hash(entities))
       end
 
+      def entity_exists?(group, entity_id)
+        return false unless entities_exist?(group)
+
+        entities = build_entities(entities(group))
+        entities.key?(entity_id)
+      end
+
       # Indicates the 'default' discovery profile URL for the
       # supplied entity_id
       def default_discovery_response(group, entity_id)

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -19,30 +19,37 @@ module DiscoveryService
         if return_url&.present?
           if DiscoveryService.configuration[:environment][:restrict_return_url]
             if valid_return_url(params, return_url)
-              logger.info("Return URL provided by '#{params[:entityID]}' was valid")
+              logger.info(''"Return URL provided for
+                          '#{params[:entityID]}' was valid"'')
               redirect_to(return_url, params)
             else
-              logger.error("Return URL '#{return_url}' provided by '#{params[:entityID]}' was invalid, rejecting value")
+              logger.error(''"Return URL '#{return_url}' provided for
+                           '#{params[:entityID]}' was invalid,
+                           rejecting value"'')
               redirect to('/error/invalid_return_url')
             end
           else
             if valid_return_url(params, return_url)
-              logger.info("Return URL '#{return_url}' provided by '#{params[:entityID]}' was valid (config disabled)")
+              logger.info(''"Return URL '#{return_url}' provided for
+                          '#{params[:entityID]}' was valid (config disabled)"'')
             else
-              logger.error("Return URL '#{return_url}' provided by '#{params[:entityID]}' was invalid, would be rejected (config disabled)")
+              logger.error(''"Return URL '#{return_url}'
+                           provided for '#{params[:entityID]}' was invalid,
+                           would be rejected (config disabled)"'')
             end
             redirect_to(return_url, params)
           end
         else
-          logger.info("Return URL not provided by '#{params[:entityID]}', fallback to default")
+          logger.info(''"Return URL not provided in
+                      query for '#{params[:entityID]}'"'')
           return_url = default_discovery_response(params)
           return redirect_to(return_url, params) if return_url
 
-          logger.info("Default return URL for '#{params[:entityID]}', not found")
+          logger.info("No default return URL for '#{params[:entityID]}'")
           status 404
         end
       end
-      # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+      # rubocop:enable
 
       private
 

--- a/spec/lib/discovery_service/application_spec.rb
+++ b/spec/lib/discovery_service/application_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe DiscoveryService::Application do
 
   describe 'GET /discovery' do
     let(:path) { '/discovery' }
+    let(:existing_entity) { build_idp_data(['idp', group_name], 'en') }
     let(:group_name) { "#{Faker::Lorem.word}_#{Faker::Number.number(2)}-" }
 
     def run
@@ -129,7 +130,7 @@ RSpec.describe DiscoveryService::Application do
       end
 
       context 'and the idp does not exist anymore' do
-        let(:existing_entity) { build_idp_data(['idp', group_name], 'en') }
+        let(:entity_exists) { build_idp_data(['idp', group_name], 'en') }
         let(:entity_id) { Faker::Internet.url }
         it 'shows that there are no organisations selected' do
           configure_group
@@ -144,8 +145,6 @@ RSpec.describe DiscoveryService::Application do
       end
 
       context 'and the idp and group do exist' do
-        let(:existing_entity) { build_idp_data(['idp', group_name], 'en') }
-
         before do
           configure_group
           redis.set("entities:#{group_name}",
@@ -625,8 +624,12 @@ RSpec.describe DiscoveryService::Application do
 
       context 'with passive and return parameters' do
         let(:selected_idp) { build_idp_data(['idp', group_name]) }
-        let(:entity_id) { Faker::Internet.url }
-        let(:sp_return_url) { Faker::Internet.url }
+        let(:existing_sp) { build_sp_data(['sp', group_name]) }
+        let(:entity_id) { existing_sp[:entity_id] }
+        let(:requesting_sp) { existing_sp[:entity_id] }
+        let(:sp_return_url) do
+          existing_sp[:all_discovery_response_endpoints].first
+        end
         let(:selected_idp_entity_id) { selected_idp[:entity_id] }
         let(:passive) { 'true' }
 
@@ -635,9 +638,14 @@ RSpec.describe DiscoveryService::Application do
           "&isPassive=#{passive}&return=#{sp_return_url}"
         end
 
+        before do
+          configure_group
+          redis.set("entities:#{group_name}",
+                    to_hash([existing_sp, selected_idp]).to_json)
+        end
+
         context 'without cookies' do
           before do
-            configure_group
             run
           end
 
@@ -652,8 +660,6 @@ RSpec.describe DiscoveryService::Application do
 
         context 'with cookies' do
           before do
-            configure_group
-            redis.set("entities:#{group_name}", to_hash([selected_idp]).to_json)
             rack_mock_session.cookie_jar['selected_organisations'] =
               JSON.generate(group_name => selected_idp_entity_id)
             run
@@ -673,8 +679,8 @@ RSpec.describe DiscoveryService::Application do
 
       context 'with passive parameter but no return' do
         let(:selected_idp) { build_idp_data(['idp', group_name]) }
-        let(:entity_id) { Faker::Internet.url }
-        let(:sp_return_url) { Faker::Internet.url }
+        let(:existing_sp) { build_sp_data_no_return(['sp', group_name]) }
+        let(:entity_id) { existing_sp[:entity_id] }
         let(:selected_idp_entity_id) { selected_idp[:entity_id] }
         let(:passive) { 'true' }
 
@@ -683,9 +689,14 @@ RSpec.describe DiscoveryService::Application do
           "&isPassive=#{passive}"
         end
 
+        before do
+          configure_group
+          redis.set("entities:#{group_name}",
+                    to_hash([existing_sp]).to_json)
+        end
+
         context 'without cookies' do
           before do
-            configure_group
             run
           end
 
@@ -696,8 +707,6 @@ RSpec.describe DiscoveryService::Application do
 
         context 'with cookies' do
           before do
-            configure_group
-            redis.set("entities:#{group_name}", to_hash([selected_idp]).to_json)
             rack_mock_session.cookie_jar['selected_organisations'] =
               JSON.generate(group_name => selected_idp_entity_id)
             run
@@ -709,14 +718,10 @@ RSpec.describe DiscoveryService::Application do
         end
 
         context 'with cookies and discovery response stored' do
-          let(:existing_entity) { build_sp_data(['sp', group_name]) }
-          let(:entity_id) { existing_entity[:entity_id] }
+          let(:existing_sp) { build_sp_data(['sp', group_name]) }
           before do
-            configure_group
-            redis.set("entities:#{group_name}",
-                      to_hash([existing_entity]).to_json)
             rack_mock_session.cookie_jar['selected_organisations'] =
-              JSON.generate(group_name => existing_entity[:entity_id])
+              JSON.generate(group_name => existing_sp[:entity_id])
             run
           end
 
@@ -725,8 +730,8 @@ RSpec.describe DiscoveryService::Application do
           end
 
           it 'redirects back to sp using discovery response value' do
-            expect_matching_response(existing_entity[:discovery_response],
-                                     'entityID' => existing_entity[:entity_id])
+            expect_matching_response(existing_sp[:discovery_response],
+                                     'entityID' => existing_sp[:entity_id])
           end
         end
       end
@@ -948,12 +953,34 @@ RSpec.describe DiscoveryService::Application do
         end
       end
 
+      context 'with unknown entity_id' do
+        let(:path) { "#{base_path}?entityID=#{Faker::Internet.url}" }
+
+        before do
+          redis.set("entities:#{group_name}",
+                    to_hash([existing_sp, existing_idp]).to_json)
+          run
+        end
+
+        it 'returns http status code 302' do
+          expect(last_response.status).to eq(302)
+        end
+
+        it 'shows error page for unknown entity' do
+          expect_matching_response(
+            'http://example.org/error/invalid_entity_id', {}
+          )
+        end
+      end
+
       context 'with an entity id parameter, no return parameter and no'\
               ' discovery response stored' do
+        let(:existing_sp) { build_sp_data_no_return(['sp', group_name]) }
         let(:path) { "#{base_path}?entityID=#{requesting_sp}" }
 
         before do
-          redis.set("entities:#{group_name}", to_hash([existing_idp]).to_json)
+          redis.set("entities:#{group_name}",
+                    to_hash([existing_sp, existing_idp]).to_json)
           run
         end
 

--- a/spec/support/build_entity_data.rb
+++ b/spec/support/build_entity_data.rb
@@ -23,6 +23,15 @@ RSpec.shared_context 'build_entity_data' do
     entity_data
   end
 
+  def build_sp_data_no_return(tags = nil, lang = nil)
+    entity_data = build_entity_data(tags, lang)
+    entity_data[:information_urls] = [{ url: Faker::Internet.url, lang: lang }]
+    entity_data[:descriptions] = [{ value: Faker::Lorem.sentence, lang: lang }]
+    entity_data[:privacy_statement_urls] =
+      [{ url: Faker::Internet.url, lang: lang }]
+    entity_data
+  end
+
   def to_hash(entities)
     Hash[entities.map { |e| [e[:entity_id], e.except(:entity_id)] }]
   end

--- a/views/_support.slim
+++ b/views/_support.slim
@@ -1,5 +1,5 @@
 p
-  | Please report this error to 
+  | If you need assistance please report this error to 
   a href="mailto:support@aaf.edu.au" support@aaf.edu.au
   |  and include a description of what you were trying to do so we help get this 
   | fixed up.

--- a/views/_support.slim
+++ b/views/_support.slim
@@ -1,5 +1,5 @@
 p
-  | If you need assistance please report this error to 
-  a href="mailto:support@aaf.edu.au" support@aaf.edu.au
-  |  and include a description of what you were trying to do so we help get this 
-  | fixed up.
+  | If you need assistance please report this error to
+  a<> href="mailto:support@aaf.edu.au" support@aaf.edu.au
+  ' and include a description of what you were trying to do so we help get this
+  ' fixed up.

--- a/views/invalid_entity_id.slim
+++ b/views/invalid_entity_id.slim
@@ -1,0 +1,16 @@
+h2 Unknown service
+p We received a request that is not valid.
+p 
+  'The cause of this fault is an unknown
+  strong> entity identifier
+  |being provided by the service being accesed.
+p 
+  'This value was provided as the parameter
+  strong> entityID
+  |by your browser during this request.
+p 
+  'If this is a newly registered service our systems may not have caught up yet. 
+  |Please allow upto 2 hours after registration approval for new services to be recognised.
+
+== Slim::Template.new('views/_support.slim').render
+br /


### PR DESCRIPTION
Previously users hitting the DS from a service that is unknown to the federation based on entityID would receive an error indicating that the return parameter was invalid.

AAF support had indicated this was sub-optimal especially for new registrations.

This change provides a specific error message in the case the destination service is unknown and provides advice for the service registrants to retry the discovery process after sufficient time has passed post approval.