### PR TITLE
 Enforce return param bypass/logging/check 

### DIFF
--- a/config/discovery_service.yml.dist
+++ b/config/discovery_service.yml.dist
@@ -21,7 +21,6 @@
 :environment:
   :name: 'Test Environment'
   :status_url: 'http://status.test.aaf.edu.au'
-  :restrict_return_url: true
 
 :sqs:
   :fake: true

--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -4,58 +4,22 @@ module DiscoveryService
   module Response
     # Module to handle user redirect / response
     module Handler
-      # rubocop:disable Metrics/LineLength, Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       def handle_response(params)
         # Flow per sstc-saml-idp-discovery 2.4/5
         # Attempt to return to metadata valid return parameter else fallback
         # to default discovery service url specified for this SP
-        return_url = params[:return]
-
         unless known_sp?(params)
           logger.info(''"Unable to locate the entityID
             '#{params[:entityID]}', halting response"'')
           return redirect to('/error/invalid_entity_id')
         end
 
-        # This is more verbose than necessary so we can log what is going on
-        # in detail with config disabled. Ideally over some period of time
-        # we won't see any cases where a return URL will not be blocked
-        # due to data already existing or being added to metadata and
-        # this code will be simplified.
-        if return_url&.present?
-          if DiscoveryService.configuration[:environment][:restrict_return_url]
-            if valid_return_url(params, return_url)
-              logger.info(''"Return URL provided for
-                          '#{params[:entityID]}' was valid"'')
-              redirect_to(return_url, params)
-            else
-              logger.error(''"Return URL '#{return_url}' provided for
-                           '#{params[:entityID]}' was invalid,
-                           rejecting value"'')
-              redirect to('/error/invalid_return_url')
-            end
-          else
-            if valid_return_url(params, return_url)
-              logger.info(''"Return URL '#{return_url}' provided for
-                          '#{params[:entityID]}' was valid (config disabled)"'')
-            else
-              logger.error(''"Return URL '#{return_url}'
-                           provided for '#{params[:entityID]}' was invalid,
-                           would be rejected (config disabled)"'')
-            end
-            redirect_to(return_url, params)
-          end
+        if params[:return]&.present?
+          handle_return_url(params)
         else
-          logger.info(''"Return URL not provided in
-                      query for '#{params[:entityID]}'"'')
-          return_url = default_discovery_response(params)
-          return redirect_to(return_url, params) if return_url
-
-          logger.info("No default return URL for '#{params[:entityID]}'")
-          status 404
+          handle_no_return_url(params)
         end
       end
-      # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
       private
 
@@ -63,7 +27,31 @@ module DiscoveryService
         @entity_cache.entity_exists?(params[:group], params[:entityID])
       end
 
-      def valid_return_url(params, return_url)
+      def handle_return_url(params)
+        return_url = params[:return]
+        if valid_return_url(params)
+          logger.info(''"Return URL provided for
+                      '#{params[:entityID]}' was valid"'')
+          redirect_to(return_url, params)
+        else
+          logger.error(''"Return URL '#{return_url}' provided for
+                       '#{params[:entityID]}' was invalid, rejecting value"'')
+          redirect to('/error/invalid_return_url')
+        end
+      end
+
+      def handle_no_return_url(params)
+        logger.info(''"Return URL not provided in
+                    query for '#{params[:entityID]}'"'')
+        return_url = default_discovery_response(params)
+        return redirect_to(return_url, params) if return_url
+
+        logger.info("No default return URL for '#{params[:entityID]}'")
+        status 404
+      end
+
+      def valid_return_url(params)
+        return_url = params[:return]
         # Per sstc-saml-idp-discovery the query path is not relevant
         # remove it if it exists in the return_url
         ru = return_url [/^[^\?]+/]

--- a/spec/lib/discovery_service/application_spec.rb
+++ b/spec/lib/discovery_service/application_spec.rb
@@ -1033,11 +1033,10 @@ RSpec.describe DiscoveryService::Application do
           end
         end
 
-        context 'with enforcing return url configured' do
+        context 'ensure return url param is enforced per spec' do
           let(:config) do
             { groups: {}, environment:
-              { name: environment_name, status_url: environment_status_url,
-                restrict_return_url: true } }
+              { name: environment_name, status_url: environment_status_url } }
           end
 
           context 'with valid return url provided' do


### PR DESCRIPTION
Removes all code that allowed the DS to operate in a permissive mode whilst we migrated to a strongly enforced position for the return parameter per the discovery specification, sections 2.4/5.

This has allowed Rubocop warnings to be re-instated.