### PR TITLE
Update Nokigiri to 1.10.4 - CVE-2019-5477

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
   gem 'webmock'
 
   gem 'capybara', require: false
-  gem 'nokogiri', '1.10.3'
+  gem 'nokogiri', '>= 1.10'
   gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'poltergeist', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     nenv (0.3.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -243,7 +243,7 @@ DEPENDENCIES
   hashdiff
   i18n (~> 0.7.0)
   json-jwt
-  nokogiri (= 1.10.3)
+  nokogiri (>= 1.10)
   phantomjs
   poltergeist
   pry


### PR DESCRIPTION
A command injection vulnerability in Nokogiri v1.10.3 and earlier allows
commands to be executed in a subprocess via Ruby's Kernel.open method.
Processes are vulnerable only if the undocumented method
Nokogiri::CSS::Tokenizer#load_file is being called with unsafe user
input as the filename. This vulnerability appears in code generated by
the Rexical gem versions v1.0.6 and earlier. Rexical is used by Nokogiri
to generate lexical scanner code for parsing CSS queries. The underlying
vulnerability was addressed in Rexical v1.0.7 and Nokogiri upgraded to
this version of Rexical in Nokogiri v1.10.4.