### PR TITLE
Bugfix search idp names with punctuation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config/deploy.yml
 config/event_encryption_key.pem
 .sass-cache
 .idea
+dump.rdb

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -184,7 +184,7 @@ function searchActiveIdPList(input, key) {
     table_rows.removeClass("active");
 
     var val = $.trim(input.val())
-      .replace(/[\W+_]/gi, "")
+      .replace(/[\W\d\s]/gi, "")
       .toLowerCase();
     if (val == "") {
       table_rows.attr("hidden", false);

--- a/views/_support.slim
+++ b/views/_support.slim
@@ -1,5 +1,5 @@
 p
   | If you need assistance please report this error to
-  a<> href="mailto:support@aaf.edu.au" support@aaf.edu.au
+  a<> href="https://support.aaf.edu.au" https://support.aaf.edu.au
   ' and include a description of what you were trying to do so we help get this
   ' fixed up.

--- a/views/group.slim
+++ b/views/group.slim
@@ -38,7 +38,7 @@ div[id="sp"]
             table[class="idp_selection_table"]
               tbody
                 - @idps.select{|idp| idp[:tags].include?(tag_group[:tag])}.each do |idp|
-                  tr[class="idp" data-idp-name="#{idp[:name].downcase.gsub(/\s+/, "")}"]
+                  tr[class="idp" data-idp-name="#{idp[:name].downcase.gsub(/[\W\d\s]/, "")}"]
                     td
                       == idp[:name]
                     td

--- a/views/layout.slim
+++ b/views/layout.slim
@@ -20,6 +20,6 @@ html lang='en'
       div[id="status" class="inline"]
         a href="#{@environment[:status_url]}" target="_blank" tabindex="-1" alt="Current systems status for the AAF"
           | Current AAF status
-        a href="mailto:support@aaf.edu.au" alt="Get AAF support"
+        a href="https://support.aaf.edu.au" alt="Get AAF support"
           | Contact AAF support
 


### PR DESCRIPTION
The encoding used for `data-idp-name` would cause searches for IdP names containing punctuation, such as apostrophe, to remove valid records when users entered the character.

Punctuation and numerics are no longer considered in searches following this change providing a more flexible end user experience.