### PR TITLE
Handler: fix logging messages to be single line

### DIFF
--- a/lib/discovery_service/response/handler.rb
+++ b/lib/discovery_service/response/handler.rb
@@ -9,8 +9,8 @@ module DiscoveryService
         # Attempt to return to metadata valid return parameter else fallback
         # to default discovery service url specified for this SP
         unless known_sp?(params)
-          logger.info(''"Unable to locate the entityID
-            '#{params[:entityID]}', halting response"'')
+          logger.info('Unable to locate the entityID '\
+            "'#{params[:entityID]}', halting response")
           return redirect to('/error/invalid_entity_id')
         end
 
@@ -30,19 +30,19 @@ module DiscoveryService
       def handle_return_url(params)
         return_url = params[:return]
         if valid_return_url(params)
-          logger.info(''"Return URL provided for
-                      '#{params[:entityID]}' was valid"'')
+          logger.info('Return URL provided for '\
+                      "'#{params[:entityID]}' was valid")
           redirect_to(return_url, params)
         else
-          logger.error(''"Return URL '#{return_url}' provided for
-                       '#{params[:entityID]}' was invalid, rejecting value"'')
+          logger.error("Return URL '#{return_url}' provided for "\
+                       "'#{params[:entityID]}' was invalid, rejecting value")
           redirect to('/error/invalid_return_url')
         end
       end
 
       def handle_no_return_url(params)
-        logger.info(''"Return URL not provided in
-                    query for '#{params[:entityID]}'"'')
+        logger.info('Return URL not provided in '\
+                    "query for '#{params[:entityID]}'")
         return_url = default_discovery_response(params)
         return redirect_to(return_url, params) if return_url
 


### PR DESCRIPTION
Hi @bradleybeddoes , I noticed the code validating the DS return URLs was logging with the log message containing a newline:

```
I, [2019-12-06T14:25:43.023390 #17152]  INFO -- : Return URL provided for
                      'https://attributes.dev.tuakiri.ac.nz/shibboleth' was valid
```

I assume the newline was not intentional - so fixing the syntax to remove the unintended newline.

Does this fit your intended coding style?  (And happy to merge?) 

Cheers,
Vlad
 