### PR TITLE
Pin redis to 4.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'unicorn', require: false
 
 gem 'aws-sdk', '~> 2', require: false
 
-gem 'redis'
+gem 'redis', '4.1.3'
 gem 'redis-namespace'
 gem 'slim'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.2.0)
+    redis (4.1.3)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     ref (2.0.0)
@@ -258,7 +258,7 @@ DEPENDENCIES
   rails-assets-jquery.scrollbar!
   rails-assets-mousetrap!
   rails-assets-picnic!
-  redis
+  redis (= 4.1.3)
   redis-namespace
   rspec
   rubocop-faker


### PR DESCRIPTION
Await for release of redis 4.3 with supporting redis-namespace gem so we can upgrade without deprecation warnings. Thanks @vladimir-mencl-eresearch for picking this up.

See https://github.com/ausaccessfed/discovery-service/pull/131#issuecomment-642368666.