### PR TITLE
Correctly handle ED that acts as both IDP and SP

### DIFF
--- a/lib/discovery_service/metadata/saml_service_client.rb
+++ b/lib/discovery_service/metadata/saml_service_client.rb
@@ -16,7 +16,7 @@ module DiscoveryService
           response.value # Raise exception on HTTP error
           JSON.parse(response.body, symbolize_names: true)
         end
-      rescue Net::HTTPServerException => e
+      rescue Net::HTTPClientException => e
         log_error(e, saml_service_url)
         raise e
       end

--- a/lib/discovery_service/renderer/controller/group.rb
+++ b/lib/discovery_service/renderer/controller/group.rb
@@ -13,22 +13,29 @@ module DiscoveryService
         def generate_group_model(entities, lang, tag_groups)
           result = { idps: [], sps: [] }
           tag_set = Set.new
-          entities.nil? || entities.each_with_object(result) do |e, hash|
-            entity_type = entity_type_from_tags(e)
-            next unless entity_type
+          entities.nil? || entities.each_with_object(result) do |entity, hash|
+            entity_types = entity_types_from_tags(entity)
+            next if entity_types.empty?
 
-            entry = build_entry(e, lang, entity_type)
-            hash[entity_type] << entry
-            tag_set.merge(entry[:tags])
+            entity_types.each { |et| generate_entity_model(entity, hash, tag_set, lang, et) }
           end
+
           build_model(result, tag_groups, tag_set)
         end
 
         private
 
-        def entity_type_from_tags(entity)
-          return :sps if entity[:tags].include?('sp')
-          return :idps if entity[:tags].include?('idp')
+        def generate_entity_model(entity, hash, tag_set, lang, entity_type)
+          entry = build_entry(entity, lang, entity_type)
+          hash[entity_type] << entry
+          tag_set.merge(entry[:tags])
+        end
+
+        def entity_types_from_tags(entity)
+          entity_types = []
+          entity_types.push(:sps) if entity[:tags].include?('sp')
+          entity_types.push(:idps) if entity[:tags].include?('idp')
+          entity_types
         end
 
         def build_model(result, tag_groups, tag_set)

--- a/spec/lib/discovery_service/metadata/saml_service_client_spec.rb
+++ b/spec/lib/discovery_service/metadata/saml_service_client_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe DiscoveryService::Metadata::SAMLServiceClient do
       end
 
       it 'propagates the exception' do
-        expect { run }.to raise_error(Net::HTTPServerException)
+        expect { run }.to raise_error(Net::HTTPClientException)
         expect(logger).to have_received(:error)
       end
     end

--- a/spec/lib/discovery_service/metadata/updater_spec.rb
+++ b/spec/lib/discovery_service/metadata/updater_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe DiscoveryService::Metadata::Updater do
       let(:response) { { status: 400, body: JSON.generate([]) } }
 
       it 'propagates the exception' do
-        expect { run }.to raise_error(Net::HTTPServerException)
+        expect { run }.to raise_error(Net::HTTPClientException)
         expect(logger).to have_received(:error)
       end
     end

--- a/spec/lib/discovery_service/renderer/controller/group_spec.rb
+++ b/spec/lib/discovery_service/renderer/controller/group_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe DiscoveryService::Renderer::Controller::Group do
       context 'the tag groups' do
         subject { run.tag_groups }
         it 'get filtered' do
-          p subject
           expect(subject).to eq([tag_group_1])
         end
       end

--- a/spec/lib/discovery_service/renderer/controller/group_spec.rb
+++ b/spec/lib/discovery_service/renderer/controller/group_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe DiscoveryService::Renderer::Controller::Group do
       end
     end
 
+    context 'with entity acting in multiple roles tag group' do
+      let(:idp_sp) { build_idp_data(['idp', 'sp', tag_group_1[:tag]]) }
+      let(:entities) { [idp_sp] }
+      context 'the tag groups' do
+        subject { run.tag_groups }
+        it 'get filtered' do
+          p subject
+          expect(subject).to eq([tag_group_1])
+        end
+      end
+    end
+
     context 'with multiple entities belonging in multiple tag groups' do
       let(:idp1) { build_idp_data(['idp', tag_group_1[:tag]]) }
       let(:idp2) { build_idp_data(['idp', tag_group_2[:tag]]) }


### PR DESCRIPTION
We previously classified ED as either an IDP or an SP. We've found within eduGAIN feeds however
that ADFS deployments ship metadata that actually advertise both roles for a single ED.

This led to our DS not showing IDP within this classification as we only considered their SP role.

Our processing now considers all `entity_type` tags an entity may carry and adds an entry for each
type to the overall model.

Support ticket reference: https://aaf.freshdesk.com/a/tickets/8416
Internal Ticket: #134

n.b. 2 extra commits in this PR that address minor project errors I encountered whilst working on this bug.