### PR TITLE
Prevent failure when UTF8 provided in UserAgent

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -11,6 +11,18 @@ The discovery service works differently to most web applications:
 You will require a ruby and redis installation on the machine you're developing
 on. For developers on OSX rbenv and homebrew will assist here.
 
+You may need to create ~/.aaf/event_encryption_key.pem, if so:
+
+```
+openssl genrsa -out ~/.aaf/event_encryption_key.pem 2048
+```
+
+Starting Redis using Homebrew install:
+
+```
+redis-server /usr/local/etc/redis.conf
+```
+
 ## Development process
 
 1. Run `./bin/setup` to configure your local environment.

--- a/lib/discovery_service/auditing.rb
+++ b/lib/discovery_service/auditing.rb
@@ -36,11 +36,20 @@ module DiscoveryService
 
     def base_data(request, params)
       {
-        user_agent: request.user_agent,
+        user_agent: request.user_agent&.encode(Encoding.find('ASCII'), encoding_options),
         ip: request.ip,
         initiating_sp: params[:entityID],
         timestamp: Time.now.utc.xmlschema,
         group: params[:group]
+      }
+    end
+
+    def encoding_options
+      {
+        invalid: :replace, # Replace invalid byte sequences - important for UA being presented with UTF8 char
+        undef: :replace, # Replace anything not defined in ASCII
+        replace: '',
+        universal_newline: true
       }
     end
   end


### PR DESCRIPTION
When receiving UserAgent values with UTF8 content the following error
was occured, resulting in end users acquiring a 500 response:

```
2020-08-28 08:03:00 - Encoding::UndefinedConversionError - "\xC3" from ASCII-8BIT to UTF-8:
        .rbenv/versions/2.7.1/lib/ruby/2.7.0/json/common.rb:224:in `generate'
        .rbenv/versions/2.7.1/lib/ruby/2.7.0/json/common.rb:224:in `generate'
        discovery-service/lib/discovery_service/auditing.rb:33:in `record_entry'
```

UTF8 in http headers seems to be an edge case at best and possibly
breaks RFC, but regardless we should be accepting it without error.

Result here is to strip any UTF8 we are provided with, this is fine for
our purposes as we only store UA to assist in debugging.

Closes https://github.com/ausaccessfed/discovery-service/issues/136
References https://github.com/ausaccessfed/stockpile/issues/66