### PR TITLE
Fix warning created in prior PR

### DIFF
--- a/lib/discovery_service/auditing.rb
+++ b/lib/discovery_service/auditing.rb
@@ -35,8 +35,10 @@ module DiscoveryService
     end
 
     def base_data(request, params)
+      ua = request.user_agent&.encode(Encoding.find('ASCII'), **encoding_options)
+
       {
-        user_agent: request.user_agent&.encode(Encoding.find('ASCII'), encoding_options),
+        user_agent: ua,
         ip: request.ip,
         initiating_sp: params[:entityID],
         timestamp: Time.now.utc.xmlschema,


### PR DESCRIPTION
The prior commit resulted in log output of:

```
warning: Using the last argument as keyword parameters is deprecated
```