### PR TITLE
Set HSTS header on all responses

### DIFF
--- a/lib/discovery_service/application.rb
+++ b/lib/discovery_service/application.rb
@@ -59,6 +59,10 @@ module DiscoveryService
       group_configured?(group) && @entity_cache.group_page_exists?(group)
     end
 
+    before do
+      response['Strict-Transport-Security'] = 'max-age=31556952; includeSubDomains'
+    end
+
     get '/' do
       redirect to('/discovery')
     end

--- a/spec/lib/discovery_service/application_spec.rb
+++ b/spec/lib/discovery_service/application_spec.rb
@@ -87,6 +87,11 @@ RSpec.describe DiscoveryService::Application do
         .to start_with('application/javascript')
       expect(last_response.body).to include('AAF Embedded WAYF')
     end
+
+    it 'sets HSTS header' do
+      run
+      expect(last_response.headers['Strict-Transport-Security']).to eq('max-age=31556952; includeSubDomains')
+    end
   end
 
   describe 'GET /discovery' do
@@ -98,6 +103,11 @@ RSpec.describe DiscoveryService::Application do
 
     def run
       get path
+    end
+
+    it 'sets HSTS header' do
+      run
+      expect(last_response.headers['Strict-Transport-Security']).to eq('max-age=31556952; includeSubDomains')
     end
 
     context 'with no idps previously selected' do
@@ -116,6 +126,11 @@ RSpec.describe DiscoveryService::Application do
         run
         expect(last_response.body).to include(environment_status_url)
       end
+
+      it 'sets HSTS header' do
+        run
+        expect(last_response.headers['Strict-Transport-Security']).to eq('max-age=31556952; includeSubDomains')
+      end
     end
 
     context 'with idps previously selected' do
@@ -128,6 +143,7 @@ RSpec.describe DiscoveryService::Application do
           run
           expect(last_response.body)
             .to include('You have no saved organisations')
+          expect(last_response.headers['Strict-Transport-Security']).to eq('max-age=31556952; includeSubDomains')
         end
       end
 
@@ -143,6 +159,7 @@ RSpec.describe DiscoveryService::Application do
           run
           expect(last_response.body)
             .to include('You have no saved organisations')
+          expect(last_response.headers['Strict-Transport-Security']).to eq('max-age=31556952; includeSubDomains')
         end
       end
 
@@ -193,6 +210,10 @@ RSpec.describe DiscoveryService::Application do
                             existing_entity[:names].first[:value]
                           ))
           end
+
+          it 'sets HSTS header' do
+            expect(last_response.headers['Strict-Transport-Security']).to eq('max-age=31556952; includeSubDomains')
+          end
         end
       end
 
@@ -236,6 +257,10 @@ RSpec.describe DiscoveryService::Application do
           expect(last_response.body).to include('When you access a service, '\
           'you will be automatically sent to one of these organisations to'\
           ' log in.')
+        end
+
+        it 'sets HSTS header' do
+          expect(last_response.headers['Strict-Transport-Security']).to eq('max-age=31556952; includeSubDomains')
         end
       end
 


### PR DESCRIPTION
Updates DS to have a HSTS header for all responses.

Closes #140
References ausaccessfed/infrastructure#340